### PR TITLE
Adding a second 'timeout' file to the test data

### DIFF
--- a/js/mockfs.js
+++ b/js/mockfs.js
@@ -24,7 +24,8 @@
         b : {
             aa : "file",
             bb : "error",
-            cc : "file"
+            cc : "file",
+            dd : "timeout"
         },
         c : "file",
         d : {


### PR DESCRIPTION
This makes it obvious that one can not simply rely on an internal timeout() to output/callback with the results
